### PR TITLE
Hotfix for Jamf token endpoint

### DIFF
--- a/src/classes/facades/Jamf/Auth.py
+++ b/src/classes/facades/Jamf/Auth.py
@@ -41,7 +41,7 @@ class JamfBearerAuth(requests.auth.AuthBase):
     """ Get a token
     """
     def getToken(self):
-        url="/api/auth/tokens"
+        url="/api/v1/auth/token"
 
         rtn = requests.post(f'{self._server}{url}',
             auth=HTTPBasicAuth(self._username, self._password), headers={'Accept': 'application/json'})


### PR DESCRIPTION
Jamf changed the API endpoint to get an auth token.  This is a hotfix to resolve that issue.